### PR TITLE
capricorn: Move qdcm calibration files to /vendor

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -200,10 +200,10 @@ vendor/lib/libmmcamera_ov4688_primax_a7.so
 vendor/lib/libSonyIMX378PdafLibrary.so
 
 # Display calibration data
--etc/qdcm_calib_data_jdi_fhd_cmd_incell_dsi_panel.xml
--etc/qdcm_calib_data_jdi_j1_fhd_cmd_incell_dsi_panel.xml
--etc/qdcm_calib_data_lgd_fhd_cmd_incell_dsi_panel.xml
--etc/qdcm_calib_data_sharp_fhd_cmd_incell_dsi_panel.xml
+etc/qdcm_calib_data_jdi_fhd_cmd_incell_dsi_panel.xml:vendor/etc/qdcm_calib_data_jdi_fhd_cmd_incell_dsi_panel.xml
+etc/qdcm_calib_data_jdi_j1_fhd_cmd_incell_dsi_panel.xml:vendor/etc/qdcm_calib_data_jdi_j1_fhd_cmd_incell_dsi_panel.xml
+etc/qdcm_calib_data_lgd_fhd_cmd_incell_dsi_panel.xml:vendor/etc/qdcm_calib_data_lgd_fhd_cmd_incell_dsi_panel.xml
+etc/qdcm_calib_data_sharp_fhd_cmd_incell_dsi_panel.xml:vendor/etc/qdcm_calib_data_sharp_fhd_cmd_incell_dsi_panel.xml
 
 # Fingerprint
 -app/QFingerprintService/QFingerprintService.apk


### PR DESCRIPTION
 * At the same time, stop making them build targets

Change-Id: I2a3d8ae5b78b9102e6061a62e013ad24ff618fc8